### PR TITLE
Fbprophet Setup fix for matplotlib

### DIFF
--- a/notebooks/forecasting-the-stock-market.ipynb
+++ b/notebooks/forecasting-the-stock-market.ipynb
@@ -299,7 +299,7 @@
    "source": [
     "# Install required packages (this can take some minutes)\n",
     "# UPDATE(vnderlev): setuptools-git is now required for fbprophet 0.5. \n",
-    "!pip install --user pystan==2.17.1.0 holidays==0.9.8 setuptools-git==1.2 matplotlib=3.0.2 --upgrade"
+    "!pip install --user pystan==2.17.1.0 holidays==0.9.8 setuptools-git==1.2 matplotlib==3.0.2 --upgrade"
    ]
   },
   {


### PR DESCRIPTION
From Notebook:
forecasting-the-stock-market.ipynb

Line 302 updated:
from:
    "!pip install --user pystan==2.17.1.0 holidays==0.9.8 setuptools-git==1.2 matplotlib=3.0.2 --upgrade"
to:
    "!pip install --user pystan==2.17.1.0 holidays==0.9.8 setuptools-git==1.2 matplotlib==3.0.2 --upgrade"